### PR TITLE
Delete condition expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/spec/acceptance/globalTableTest.spec.ts
+++ b/spec/acceptance/globalTableTest.spec.ts
@@ -238,6 +238,39 @@ describe('Global table tests', function ()
         assert.deepEqual(book, { id: 2, title: 'That Book' });
     });
 
+    it('Delete an item - failed condition, no delete', async () =>
+    {
+        assert.isDefined(await nodenamo.get(1).from(User).execute());
+        assert.isDefined(await nodenamo.get(1).from(Book).execute());
+        assert.equal((await nodenamo.list().from(User).execute()).items.length, 3);
+        assert.equal((await nodenamo.list().from(Book).execute()).items.length, 2);
+
+        let error = undefined;
+
+        try
+        {
+            await nodenamo.delete(1).from(User).where({
+                conditionExpression:"#name = :name",
+                expressionAttributeNames:{
+                    ["#name"]:'name'
+                },
+                expressionAttributeValues:{
+                    [":name"]:"Not Some One"
+                }
+            }).execute();
+        }
+        catch(e)
+        {
+            error = e;
+        }
+        
+        assert.isDefined(error);
+        assert.deepEqual(await nodenamo.get(1).from(User).execute(), { id: 1, name: 'Some One' });
+        assert.isDefined(await nodenamo.get(1).from(Book).execute());
+        assert.equal((await nodenamo.list().from(User).execute()).items.length, 3);
+        assert.equal((await nodenamo.list().from(Book).execute()).items.length, 2);
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());
@@ -250,6 +283,29 @@ describe('Global table tests', function ()
         assert.isUndefined(await nodenamo.get(1).from(User).execute());
         assert.isDefined(await nodenamo.get(1).from(Book).execute());
         assert.equal((await nodenamo.list().from(User).execute()).items.length, 2);
+        assert.equal((await nodenamo.list().from(Book).execute()).items.length, 2);
+    });
+
+    it('Delete an item - condition expression succeeds', async () =>
+    {
+        assert.isDefined(await nodenamo.get(2).from(User).execute());
+        assert.isDefined(await nodenamo.get(1).from(Book).execute());
+        assert.equal((await nodenamo.list().from(User).execute()).items.length, 2);
+        assert.equal((await nodenamo.list().from(Book).execute()).items.length, 2);
+
+        await nodenamo.delete(2).from(User).where({
+            conditionExpression:"#name = :name",
+            expressionAttributeNames:{
+                ["#name"]:'name'
+            },
+            expressionAttributeValues:{
+                [":name"]:"That Two"
+            }
+        }).execute();
+
+        assert.isUndefined(await nodenamo.get(2).from(User).execute());
+        assert.isDefined(await nodenamo.get(1).from(Book).execute());
+        assert.equal((await nodenamo.list().from(User).execute()).items.length, 1);
         assert.equal((await nodenamo.list().from(Book).execute()).items.length, 2);
     });
 

--- a/spec/unit/validationDelete.spec.ts
+++ b/spec/unit/validationDelete.spec.ts
@@ -206,7 +206,7 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.isUndefined(error)
         });
 
-        it('invalid - hash/range property', async () =>
+        it('invalid - hash/range property are not allowed', async () =>
         {
             try
             {
@@ -217,7 +217,7 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.instanceOf(error, ValidationError);
         });
 
-        it('invalid - using the real property name instead of a custom name', async () =>
+        it('invalid - hash/range property are not allowed - referenced by custom name.', async () =>
         {
             try
             {
@@ -249,7 +249,7 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.isUndefined(error);
         });
 
-        it('invalid - customed name property', async () =>
+        it('invalid - custom name property', async () =>
         {
             try
             {

--- a/spec/unit/validationDelete.spec.ts
+++ b/spec/unit/validationDelete.spec.ts
@@ -206,20 +206,26 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.isUndefined(error)
         });
 
-        it('valid - hash/range property', async () =>
+        it('invalid - hash/range property', async () =>
         {
-            await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'hashProperty', "#m": 'rangeProperty'}});
+            try
+            {
+                await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'hashProperty', "#m": 'rangeProperty'}});
+            }catch(e) { error = e; }
             
-            assert.isTrue(called);
-            assert.isUndefined(error);
+            assert.isFalse(called);
+            assert.instanceOf(error, ValidationError);
         });
 
         it('valid - using the real property name instead of a custom name', async () =>
         {
-            await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'realProperty'}});
+            try
+            {
+                await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'realProperty'}});
+            }catch(e) { error = e; }
 
-            assert.isTrue(called);
-            assert.isUndefined(error);
+            assert.isFalse(called);
+            assert.instanceOf(error, ValidationError);
         });
 
         it('invalid - nonexistent property', async () =>
@@ -234,16 +240,13 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.instanceOf(error, ValidationError);
         });
 
-        it('invalid - non hash/range property', async () =>
+        it('valid - non hash/range property', async () =>
         {
-            try
-            {
-                await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'regularProperty'}});
-            }
-            catch(e) { error = e; }
 
-            assert.isFalse(called);
-            assert.instanceOf(error, ValidationError);
+            await manager.delete(Entity, 42, {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'regularProperty'}});
+
+            assert.isTrue(called);
+            assert.isUndefined(error);
         });
 
         it('invalid - customed name property', async () =>

--- a/spec/unit/validationDelete.spec.ts
+++ b/spec/unit/validationDelete.spec.ts
@@ -217,7 +217,7 @@ describe('ValidationDynamoDbManager - Delete()', function ()
             assert.instanceOf(error, ValidationError);
         });
 
-        it('valid - using the real property name instead of a custom name', async () =>
+        it('invalid - using the real property name instead of a custom name', async () =>
         {
             try
             {

--- a/src/managers/validatedDynamodbManager.ts
+++ b/src/managers/validatedDynamodbManager.ts
@@ -246,12 +246,12 @@ function validateConditionExpression<T extends object>(type:{new(...args: any[])
     if(param === undefined) return;
     
     let instance = new type();
-    let hashes = Reflector.getAllHashKeys(instance).map(hash => Key.parse(hash).propertyName);
-    let ranges = Reflector.getAllRangeKeys(instance).map(range => Key.parse(range).propertyName);
+    let hashes = [...(Reflector.getAllHashKeys(instance).map(hash => Key.parse(hash).propertyName)), Const.HashColumn];
+    let ranges = [...(Reflector.getAllRangeKeys(instance).map(range => Key.parse(range).propertyName)), Const.RangeKey];
     let columns = Reflector.getColumns(instance).map(column => Key.parse(column).propertyName);
     
     //Add hash/range/id column here because expressionAttributeNames may include one of those from keyConditions expression.
-    columns = [...columns, Const.HashColumn, Const.RangeColumn, Const.IdColumn, ...hashes, ...ranges];
+    columns = [...columns, Const.HashColumn, Const.RangeColumn, Const.IdColumn];
 
     //filterExpression
     if(param.conditionExpression === undefined || param.conditionExpression.trim().length === 0)
@@ -271,12 +271,12 @@ function validateConditionExpression<T extends object>(type:{new(...args: any[])
 
             if(hashes.includes(columnName))
             {
-                throw new ValidationError(`The hash property '${columnName}' could not be used in a filter expression. Try using it in a keyConditions expression instead.`);
+                throw new ValidationError(`The hash property '${columnName}' could not be used in a condition expression. Try using it in a keyConditions expression instead.`);
             }
 
             if(ranges.includes(columnName))
             {
-                throw new ValidationError(`The hash property '${columnName}' could not be used in a filter expression. Try using it in a keyConditions expression instead.`);
+                throw new ValidationError(`The hash property '${columnName}' could not be used in a condition expression. Try using it in a keyConditions expression instead.`);
             }
         }
     }

--- a/src/managers/validatedDynamodbManager.ts
+++ b/src/managers/validatedDynamodbManager.ts
@@ -75,7 +75,7 @@ export class ValidatedDynamoDbManager implements IDynamoDbManager
     {
         validateType(type);
         validateObjectId(id);
-        validateDeleteConditionExpression(type, params);
+        validateConditionExpression(type, params);
 
         await this.manager.delete(type, id, params, transaction, autoCommit);
     }
@@ -241,7 +241,7 @@ function validateKeyConditionExpression<T extends object>(type:{new(...args: any
     }
 }
 
-function validateDeleteConditionExpression<T extends object>(type:{new(...args: any[]):T}, param:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object})
+function validateConditionExpression<T extends object>(type:{new(...args: any[]):T}, param:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object})
 {
     if(param === undefined) return;
     
@@ -250,8 +250,8 @@ function validateDeleteConditionExpression<T extends object>(type:{new(...args: 
     let ranges = Reflector.getAllRangeKeys(instance).map(range => Key.parse(range).propertyName);
     let columns = Reflector.getColumns(instance).map(column => Key.parse(column).propertyName);
     
-    //Add hash/rane/id column here because expressionAttributeNames may include one of those from keyConditions expression.
-    columns = [...columns, Const.HashColumn, Const.RangeColumn, Const.IdColumn];
+    //Add hash/range/id column here because expressionAttributeNames may include one of those from keyConditions expression.
+    columns = [...columns, Const.HashColumn, Const.RangeColumn, Const.IdColumn, ...hashes, ...ranges];
 
     //filterExpression
     if(param.conditionExpression === undefined || param.conditionExpression.trim().length === 0)


### PR DESCRIPTION
**Issue:**

-  delete condition expressions with where currently require hash or range keys by validation; however, these can never succeed because of the conversion of named hash keys to `hash` and `range`. For example
```
conditionExpression:'#resourceLocationId = :resourceLocationId',
                expressionAttributeNames:{ 
                    ['#resourceLocationId']:'resourceLocationIdHash',
                },
                expressionAttributeValues:{
                    [':resourceLocationId']: 'NoResourceLocationId',
                }
```
produces

```
{
ConditionExpression":"#resourceLocationId = :resourceLocationId",
"ExpressionAttributeNames":{"#resourceLocationId":"hash"}, // <--- notice "hash" instead of "resourceLocationIdHash"
"ExpressionAttributeValues":{":resourceLocationId":"NoResourceLocationId"}}}
```
which will ALWAYS fail because every representation has different hash and range values.

solution:
- change validation to allow only non hash range keys.  adds acceptance test
