### PR TITLE
Reduce likelyhood of overwriting changes during consecutive updates

### DIFF
--- a/spec/unit/dynamodbManagerUpdate.spec.ts
+++ b/spec/unit/dynamodbManagerUpdate.spec.ts
@@ -20,6 +20,7 @@ describe('DynamoDbManager.Update()', function ()
     let called:boolean;
     let deleted:boolean;
     let deleted2:boolean;
+    let desiredObjectCreatedFromStronglyConsistentRead:boolean;
 
     beforeEach(()=>
     {
@@ -31,6 +32,11 @@ describe('DynamoDbManager.Update()', function ()
         called = false;
         deleted = false;
         deleted2 = false;
+        desiredObjectCreatedFromStronglyConsistentRead = false;
+    });
+
+    afterEach(()=>{
+        desiredObjectCreatedFromStronglyConsistentRead = true;
     });
 
     it('update() - no keys', async () =>
@@ -51,13 +57,13 @@ describe('DynamoDbManager.Update()', function ()
             order:number;
         };
 
+        setupStronglyConsistentRead({hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'}, {hash: 'entity#1', range: 'order', id:1, name:'Some Two', created:'created', order:'order'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
         let manager = new DynamoDbManager(mockedClient.object);
 
         await manager.update(Entity, 1, {name: 'New Two'}, undefined, mockedTransaction.object);
-
         assert.isTrue(called);
     });
 
@@ -79,6 +85,7 @@ describe('DynamoDbManager.Update()', function ()
             order:number;
         };
 
+        setupStronglyConsistentRead({hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'}, {hash: 'entity#1', range: 'order', id:1, name:'Some Two', created:'created', order:'order'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
         mockedTransaction.setup(t => t.add(It.is(t => !!t.Put && !!t.Put.TableName && t.Put.Item.hash === 'entity#1' && t.Put.Item.range === 'new created' && t.Put.Item.name === 'New Two' && t.Put.Item.created === 'new created' && t.Put.Item.order === 'new order'))).callback(()=>put=true);
@@ -111,6 +118,7 @@ describe('DynamoDbManager.Update()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'entity#nodenamo', range: 'created#1', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'entity#nodenamo', range: 'created#1', id:1, name:'Some One', created:'created', order:'order'},
             {hash: 'entity#Some One', range: 'created', id:1, name:'Some One', created:'created', order:'order'},
@@ -150,6 +158,7 @@ describe('DynamoDbManager.Update()', function ()
             order:number;
         };
 
+        setupStronglyConsistentRead({hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'}, {hash: 'entity#1', range: 'order', id:1, name:'Some Two', created:'created', order:'order'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
         mockedTransaction.setup(t => t.add(It.is(t => !!t.Put && !!t.Put.TableName && t.Put.Item.hash === 'entity#1' && t.Put.Item.range === 'created' && !t.Put.ConditionExpression && t.Put.Item.name === 'New Two' && t.Put.Item.created === 'created' && t.Put.Item.order === 'order'))).callback(()=>put=true);
@@ -183,6 +192,7 @@ describe('DynamoDbManager.Update()', function ()
             order:number;
         };
 
+        setupStronglyConsistentRead({hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'}, {hash: 'entity#1', range: 'order', id:1, name:'Some Two', created:'created', order:'order'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
         mockedTransaction.setup(t => t.add(It.is(t => !!t.Put && !!t.Put.TableName && t.Put.Item.hash === 'entity#1a' && t.Put.Item.range === 'created' && !!t.Put.ConditionExpression && t.Put.Item.id === '1a'))).callback(()=>put=true);
@@ -220,6 +230,7 @@ describe('DynamoDbManager.Update()', function ()
 
         let condition = {conditionExpression: 'condition', expressionAttributeNames: {'#n': 'name'}, expressionAttributeValues: {':v': true}};
 
+        setupStronglyConsistentRead({hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'entity#1', range: 'created', id:1, name:'Some One', created:'created', order:'order'}, {hash: 'entity#1', range: 'order', id:1, name:'Some Two', created:'created', order:'order'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
         mockedTransaction.setup(t => t.add(It.is(t => !!t.Put && !!t.Put.TableName && t.Put.Item.hash === 'entity#1' && t.Put.Item.range === 'created' && t.Put.Item.name === 'New Two' && t.Put.ConditionExpression === 'condition' && t.Put.ExpressionAttributeNames['#n'] === 'name' && t.Put.ExpressionAttributeValues[':v'] === 'true'))).callback(()=>put=true);
@@ -247,6 +258,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -278,6 +290,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -309,6 +322,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -340,6 +354,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -371,6 +386,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -462,6 +478,7 @@ describe('DynamoDbManager.Update()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({id:1, name:'Some One'});
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
         ]});
@@ -502,6 +519,7 @@ describe('DynamoDbManager.Update()', function ()
             @DBColumn()
             name:string;
         };
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
 
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
@@ -538,6 +556,7 @@ describe('DynamoDbManager.Update()', function ()
             @DBColumn()
             name:string;
         };
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
 
         let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
@@ -561,6 +580,20 @@ describe('DynamoDbManager.Update()', function ()
         assert.isDefined(error);
         assert.isTrue(error.message.includes('An object with the same ID or hash-range key already exists in \'Entity\' table'));
     });
+
+    function setupStronglyConsistentRead(expectedItem:object)
+    {
+        let stronglyConsistentResponse = getMockedGetResponse(
+            {Item:<any>expectedItem}
+        );
+        mockedClient.setup(q => q.get(It.is(p =>
+            !!p.TableName
+            && p.Key[Const.HashColumn] === 'entity#1'
+            && p.Key[Const.RangeColumn] === 'nodenamo' 
+            && p.ConsistentRead === true)))
+            .callback(()=>desiredObjectCreatedFromStronglyConsistentRead=true)
+            .returns(()=>stronglyConsistentResponse.object);
+    }
 });
 
 function getMockedGetResponse(response:GetItemOutput): IMock<Request<GetItemOutput, AWSError>>


### PR DESCRIPTION
Issue
- consecutive updates within two seconds pose the risk of overwriting changes because desired object is constructed from the result of an eventually consistent read.

This change
- desired object constructed from the result of a strongly consistent read. 