### PR TITLE
Strongly Consistent Updates and Apply uses representations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 dist/
 test.ts
 testtable.ts
+testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "1.7.2",
+  "version": "1.7.4",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/spec/unit/dynamodbManagerApply.spec.ts
+++ b/spec/unit/dynamodbManagerApply.spec.ts
@@ -18,6 +18,7 @@ describe('DynamoDbManager.Apply()', function ()
     let updated2:boolean;
     let updated3:boolean;
     let called:boolean;
+    let desiredObjectCreatedFromStronglyConsistentRead:boolean;
 
     beforeEach(()=>
     {
@@ -27,6 +28,7 @@ describe('DynamoDbManager.Apply()', function ()
         updated2 = false;
         updated3 = false;
         called = false;
+        desiredObjectCreatedFromStronglyConsistentRead = false;
     });
 
     it('apply() - set', async () =>
@@ -43,6 +45,7 @@ describe('DynamoDbManager.Apply()', function ()
             @DBColumn()
             created:number;
         };
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
 
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
@@ -74,6 +77,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - remove', async () =>
@@ -90,7 +94,7 @@ describe('DynamoDbManager.Apply()', function ()
             @DBColumn()
             created:number;
         };
-
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -121,6 +125,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - add', async () =>
@@ -138,6 +143,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -168,6 +174,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - delete', async () =>
@@ -184,7 +191,8 @@ describe('DynamoDbManager.Apply()', function ()
             @DBColumn()
             created:number;
         };
-
+    
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -215,6 +223,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - set/add/delete/remove', async () =>
@@ -232,6 +241,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -262,6 +272,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a condition', async () =>
@@ -279,6 +290,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created'}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created'}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -309,6 +321,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check', async () =>
@@ -326,6 +339,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created', objver:2}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -362,6 +376,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check (false)', async () =>
@@ -379,6 +394,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created', objver:2}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -415,6 +431,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check (table-level)', async () =>
@@ -432,6 +449,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created', objver:2}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -468,6 +486,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check (table-level) will not be overridden by withVersionCheck(false)', async () =>
@@ -485,6 +504,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created', objver:2}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -521,6 +541,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a condition and a version check', async () =>
@@ -538,6 +559,7 @@ describe('DynamoDbManager.Apply()', function ()
             created:number;
         };
 
+        setupStronglyConsistentRead({hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2});
         let findResponse = getMockedQueryResponse({Items: <any>[{hash: 'hash1', range: 'range1', id:1, name:'Some One', created:'created', objver:2}, {hash: 'hash2', range: 'range2', id:1, name:'Some Two', created:'created', objver:2}]});
         mockedClient.setup(q => q.query(It.is(p => !!p.TableName && p.IndexName === Const.IdIndexName && p.KeyConditionExpression === '#objid = :objid' && p.ExpressionAttributeNames['#objid'] === Const.IdColumn && p.ExpressionAttributeValues[':objid'] === 'entity#1'))).callback(()=>called=true).returns(()=>findResponse.object);
 
@@ -574,6 +596,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.isTrue(called);
         assert.isTrue(updated1);
         assert.isTrue(updated2);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check - failed because of versioning', async () =>
@@ -588,6 +611,7 @@ describe('DynamoDbManager.Apply()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
          //Simulate object changes from objver 1 to 2.
          let findResponse1 = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
@@ -623,6 +647,7 @@ describe('DynamoDbManager.Apply()', function ()
         assert.instanceOf(error, VersionError);
         assert.isTrue(calledGetById);
         assert.isTrue(calledGetOne);
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 
     it('apply() - with a version check - failed because of a non-versioning issue', async () =>
@@ -637,6 +662,7 @@ describe('DynamoDbManager.Apply()', function ()
             name:string;
         };
 
+        setupStronglyConsistentRead({hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'});
          //Simulate object changes from objver 1 to 2.
          let findResponse = getMockedQueryResponse({Items: <any>[
             {hash: 'hash', range: 'range', id:1, objver: 1, name:'Some One'},
@@ -661,7 +687,22 @@ describe('DynamoDbManager.Apply()', function ()
 
         assert.notInstanceOf(error, VersionError);
         assert.equal(error.message, 'Simulated error');
+        assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
+
+    function setupStronglyConsistentRead(expectedItem:object)
+    {
+        let stronglyConsistentResponse = getMockedGetResponse(
+            {Item:<any>expectedItem}
+        );
+        mockedClient.setup(q => q.get(It.is(p =>
+            !!p.TableName
+            && p.Key[Const.HashColumn] === 'entity#1'
+            && p.Key[Const.RangeColumn] === 'nodenamo' 
+            && p.ConsistentRead === true)))
+            .callback(()=>desiredObjectCreatedFromStronglyConsistentRead=true)
+            .returns(()=>stronglyConsistentResponse.object);
+    }
 });
 
 function getMockedGetResponse(response:GetItemOutput): IMock<Request<GetItemOutput, AWSError>>

--- a/src/managers/dynamodbManager.ts
+++ b/src/managers/dynamodbManager.ts
@@ -83,7 +83,7 @@ export class DynamoDbManager implements IDynamoDbManager
         }
     }
 
-    async getOne<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<T>
+    private async getOneItem<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<object>
     {
         let obj:T = new type();
         let stronglyConsistent = Reflector.getTableStronglyConsistent(obj) || params?.stronglyConsistent || false;
@@ -109,9 +109,16 @@ export class DynamoDbManager implements IDynamoDbManager
 
         let response =  await this.client.get(query).promise();
 
-        if(response.Item)
+        return response.Item;
+    }
+
+    async getOne<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<T>
+    {
+        const item =  await this.getOneItem(type,id,params);
+
+        if(item)
         {
-            return EntityFactory.create(type, response.Item);
+            return EntityFactory.create(type,item);
         }
 
         return undefined;

--- a/src/managers/dynamodbManager.ts
+++ b/src/managers/dynamodbManager.ts
@@ -83,7 +83,7 @@ export class DynamoDbManager implements IDynamoDbManager
         }
     }
 
-    private async getOneItem<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<object>
+    private async getOneRepresendationById<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<object>
     {
         let obj:T = new type();
         let stronglyConsistent = Reflector.getTableStronglyConsistent(obj) || params?.stronglyConsistent || false;
@@ -114,7 +114,7 @@ export class DynamoDbManager implements IDynamoDbManager
 
     async getOne<T extends object>(type:{new(...args: any[]):T}, id:string|number, params?:{stronglyConsistent?:boolean}): Promise<T>
     {
-        const item =  await this.getOneItem(type,id,params);
+        const item =  await this.getOneRepresendationById(type,id,params);
 
         if(item)
         {
@@ -274,7 +274,7 @@ export class DynamoDbManager implements IDynamoDbManager
         let versioningRequired = tableVersioning || (params && params.versionCheck);
 
         //Calculate new representations
-        let [rows, stronglyConsistentRow ] = await Promise.all([this.getById(id, type), this.getOneItem(type,id,{ stronglyConsistent:true})]);
+        let [rows, stronglyConsistentRow ] = await Promise.all([this.getById(id, type), this.getOneRepresendationById(type,id,{ stronglyConsistent:true})]);
         
         if(rows.length === 0)
         {
@@ -454,7 +454,7 @@ export class DynamoDbManager implements IDynamoDbManager
         let versioningRequired = tableVersioning || (params && params.versionCheck);
 
         //Calculate new representations
-        let stronglyConsistentRow = await this.getOneItem(type,id,{ stronglyConsistent:true });
+        let stronglyConsistentRow = await this.getOneRepresendationById(type,id,{ stronglyConsistent:true });
         if(!stronglyConsistentRow)
         {
             throw new Error(`Could not update the object '${id}' because it could not be found.`);

--- a/src/managers/dynamodbManager.ts
+++ b/src/managers/dynamodbManager.ts
@@ -257,7 +257,7 @@ export class DynamoDbManager implements IDynamoDbManager
 
     private assignExistingNonHashRangeValues(to:object,from:object):void
     {        
-        for(let key of Object.keys(to))
+        for(let key of Object.keys(from))
         {
             if(from[key] !== undefined && key !== Const.HashColumn && key!== Const.RangeColumn)
             {


### PR DESCRIPTION
on Update - Desired object is created from a strongly consistent read, instead of the first hit from an eventually consistent read.

on Apply - The keys used for the update transaction are gathered by generating all representations with `RepresentationFactory` from a strongly consistent read, instead of the results of an eventually consistent read.