### PR TITLE
errors seem to be formatted differently

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",


### PR DESCRIPTION
I was seeing: "Cannot read properties of of undefined (reading 'body')" from the error parsing of the error body. From what I could find, it seems we can check  for a TransactionCanceledException and check the CancellationReasons and Message directly without parsing the response:

Throws of command: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/TransactWriteItemsCommand/

TransactionCanceledException: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-dynamodb/Class/TransactionCanceledException/