### PR TITLE
Max100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/src/managers/dynamodbTransaction.ts
+++ b/src/managers/dynamodbTransaction.ts
@@ -2,7 +2,7 @@ import { ConditionCheck, Delete, Put, TransactWriteItem, Update  } from "@aws-sd
 import AggregateError from 'aggregate-error';
 import { DynamoDBDocumentClient, TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
 
-const MAX_AWS_TRANSACTION_OPERATIONS = Number(process.env.MAX_AWS_TRANSACTION_OPERATIONS) || 25;
+const MAX_AWS_TRANSACTION_OPERATIONS = Number(process.env.MAX_AWS_TRANSACTION_OPERATIONS) || 100;
 
 // We need a type to represent @aws-sdk/client-dynamodb's TransactItem but in @aws-sdk/lib-dynamodb's way.
 // The following type is the type of @aws-sdk/lib-dynamodb's TransactWriteCommandInput.TransactItems


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/

Bump max transactions to match aws limit to ensure larger transactions happen in the same batch and can be reverted