### PR TITLE
Added .returning()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ let user1 = await nodenamo.get(1).from(User).execute<User>();
 
 //Update the user
 user1.name = 'This One';
-await nodenamo.update(user1).from(User).execute(); 
-    /* Returns { items: [ User { id: 1, name: 'This One', email: 'some.one@example.com' } ],
-                 lastEvaluatedKey: undefined } */
+let originalUser = await nodenamo.update(user1).from(User).returning(ReturnValue.AllOld).execute(); 
+    /* Returns User { id: 1, name: 'Some One', email: 'some.one@example.com' } */
 
 //List all users
 let users = await nodenamo.list().from(User).execute<User>();
+    /* Returns { items: [ User { id: 1, name: 'This One', email: 'some.one@example.com' } ],
+                 lastEvaluatedKey: undefined } */
 
 //Delete the user by id
 await nodenamo.delete(1).from(User).execute();
@@ -192,6 +193,44 @@ where:
  * `hash` is the value of a hash key defined by `@DBColumn({hash:true})`
  * `range` is the prefix value of a range key defined by `@DBColumn({range:true})`
  * `indexName` is the name of an index to be used with the query.
+
+### <a name='Update'>Update an object</a>
+
+Get an object from DynamoDB by the object's ID
+
+```javascript
+// Update an object
+await nodenamo.update(object).from(T).execute<T>();
+
+// Update an object with a condition expression
+await nodenamo.update(object).from(T).where(conditionExpression, expressionAttributeNames, expressionAttributeValues).execute<T>();
+
+// Update an object and requesting for a return value.
+import { ReturnValue } from 'nodenamo';
+
+await nodenamo.update(object).from(T).returning(ReturnValue.AllOld).execute<T>();
+
+// Update an object with a version check
+await nodenamo.update(object).from(T).withVersionCheck().execute<T>();
+
+/***
+ * All operations above can be chained together.
+ ***/
+await nodenamo.update(obj)
+              .from(T)
+              .where(conditionExpression, expressionAttributeNames, expressionAttributeValues)
+              .withVersionCheck()
+              .returning(ReturnValue.AllNew)
+              .execute<T>();
+
+```
+
+where:
+ * `obj` is an object retrieved from the <a href='#Get'>Get</a> or <a href='#List'>List</a> operations or an object created from a class decorated with `@DBTable()`
+ * `T` is a class decorated with `@DBTable()`
+ * `conditionExpression` is a string representing a conditional expression for DynamoDB's PUT operation. For example, `"#name = :name"`
+ * `expressionAttributeNames` is an object representing attribute names for the conditionExpression. For example, `{ '#name': 'name' }`
+ * `expressionAttributeValues` is an object representing attribute values for the conditionExpression. For example, `{ ':name': 'Some One' }`
 
  ### Delete an object<a name='Delete'></a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenamo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A powerful ORM for DynamoDb",
   "main": "dist/index.js",
   "typings": "dist/index",

--- a/spec/acceptance/customNameTest.spec.ts
+++ b/spec/acceptance/customNameTest.spec.ts
@@ -2,7 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_targetNameTest'})
 class User
@@ -261,7 +261,9 @@ describe('Custom-name tests', function ()
 
         user.name = 'This Three';
         user['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
         
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, { id: 3, name: 'This Three', account: 2000, created: 2018, department: 'development', enabled: false });
@@ -298,6 +300,31 @@ describe('Custom-name tests', function ()
         
         user = await nodenamo.get(6).from(User).execute();
         assert.deepEqual(user, { id: 6, name: '', account: 3000, created: 2020, department: 'hr', enabled: true });
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/customNameTest.spec.ts
+++ b/spec/acceptance/customNameTest.spec.ts
@@ -341,6 +341,43 @@ describe('Custom-name tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020, department: 'hr', enabled: true });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/globalTableTest.spec.ts
+++ b/spec/acceptance/globalTableTest.spec.ts
@@ -209,7 +209,9 @@ describe('Global table tests', function ()
         assert.deepEqual(book, { id: 2, title: 'Another Book' });
 
         user.name = 'This Two';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
         
         user = await nodenamo.get(2).from(User).execute();
         assert.deepEqual(user, { id: 2, name: 'This Two' });

--- a/spec/acceptance/hashRangePairTest.spec.ts
+++ b/spec/acceptance/hashRangePairTest.spec.ts
@@ -2,7 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_hashRangePairTest'})
 class User
@@ -283,7 +283,9 @@ describe('Hash-range pair tests', function ()
 
         user.name = 'This Three';
         user['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
         
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, { id: 3, name: 'This Three', account: 2000, created: 2018, parentId: 300 });
@@ -359,6 +361,45 @@ describe('Hash-range pair tests', function ()
         
         user = await nodenamo.get(6).from(User).execute();
         assert.deepEqual(user, { id: 6, name: '', account: 3000, created: 2020, parentId: 600 });
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('Update an item - with all combinations', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Another Two'})
+                                   .from(User)
+                                   .where('#account=:account', {'#account': 'account'}, {':account': originalUser.account})
+                                   .returning(ReturnValue.AllOld)
+                                   .withVersionCheck()
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/hashRangePairTest.spec.ts
+++ b/spec/acceptance/hashRangePairTest.spec.ts
@@ -416,6 +416,43 @@ describe('Hash-range pair tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020, parentId: 600 });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/hashRangeTest.spec.ts
+++ b/spec/acceptance/hashRangeTest.spec.ts
@@ -2,7 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_hashRangeTest'})
 class User
@@ -361,7 +361,9 @@ describe('Hash-range tests', function ()
 
         user.name = 'This Three';
         user['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
 
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, { id: 3, name: 'This Three', account: 2000, created: 2018 });
@@ -438,6 +440,45 @@ describe('Hash-range tests', function ()
 
         user = await nodenamo.get(6).from(User).execute();
         assert.deepEqual(user, { id: 6, name: '', account: 3000, created: 2020 });
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('Update an item - with all combinations', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Another Two'})
+                                   .from(User)
+                                   .where('#account=:account', {'#account': 'account'}, {':account': originalUser.account})
+                                   .returning(ReturnValue.AllOld)
+                                   .withVersionCheck()
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/hashRangeTest.spec.ts
+++ b/spec/acceptance/hashRangeTest.spec.ts
@@ -495,6 +495,43 @@ describe('Hash-range tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020});
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/hashTest.spec.ts
+++ b/spec/acceptance/hashTest.spec.ts
@@ -422,6 +422,43 @@ describe('Hash tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 6000});
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/idTest.spec.ts
+++ b/spec/acceptance/idTest.spec.ts
@@ -236,7 +236,7 @@ describe('ID tests', function ()
         let result = await nodenamo.update(user3).from(User).execute();
 
         assert.isUndefined(result);
-        
+
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, {id:3, name: 'This Three', description: 'Description 3', secret: undefined, obj:{array:[], bool:true, empty:'', num:1, obj:{n:1,e:''}, str:'string'}});
     });
@@ -304,16 +304,55 @@ describe('ID tests', function ()
     {
         let user = await nodenamo.get(4).from(User).execute<User>();
 
-        await nodenamo.on(4)
-                      .from(User)
-                      .set(['#desc=:desc'], {'#desc': 'description'}, {':desc': 'That description'})
-                      .add(['#obj :obj'], {'#obj': 'obj'}, {':obj': 42})
-                      .remove(['#name'], {'#name': 'name'})
-                      .execute();
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#desc=:desc'], {'#desc': 'description'}, {':desc': 'That description'})
+                                   .add(['#obj :obj'], {'#obj': 'obj'}, {':obj': 42})
+                                   .remove(['#name'], {'#name': 'name'})
+                                   .execute();
 
         user = await nodenamo.get(4).from(User).execute();
 
+        assert.isUndefined(result);
+
         assert.deepEqual(user, {id:4, name: undefined, description: 'That description', secret: undefined, obj:<any>42});
+    });
+
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(4).from(User).execute<User>();
+
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(4).from(User).execute<User>();
+
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
     });
 
     it('Delete an item', async () =>

--- a/spec/acceptance/idTest.spec.ts
+++ b/spec/acceptance/idTest.spec.ts
@@ -2,6 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_idTest'})
 class User
@@ -232,8 +233,10 @@ describe('ID tests', function ()
 
         user3.name = 'This Three';
         user3['extra'] = 'invalid';
-        await nodenamo.update(user3).from(User).execute();
+        let result = await nodenamo.update(user3).from(User).execute();
 
+        assert.isUndefined(result);
+        
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, {id:3, name: 'This Three', description: 'Description 3', secret: undefined, obj:{array:[], bool:true, empty:'', num:1, obj:{n:1,e:''}, str:'string'}});
     });
@@ -270,6 +273,31 @@ describe('ID tests', function ()
         user = await nodenamo.get(4).from(User).execute();
 
         assert.deepEqual(user, {id:4, name: 'Some Four', description: '', secret: undefined, obj:undefined});
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'New Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/indexConsistentTest.spec.ts
+++ b/spec/acceptance/indexConsistentTest.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Const } from '../../src/const';
 
 @DBTable({name:'nodenamo_acceptance_indexConsistentTest'})

--- a/spec/acceptance/lastEvaluatedKeyWithFilterAndPagingTest.spec.ts
+++ b/spec/acceptance/lastEvaluatedKeyWithFilterAndPagingTest.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 
 @DBTable({name:'nodenamo_acceptance_lastEvaluatedKeyWithFilterAndPagingTest'})
 class User

--- a/spec/acceptance/marshallTest.spec.ts
+++ b/spec/acceptance/marshallTest.spec.ts
@@ -97,7 +97,9 @@ describe('Marshall tests', function ()
 
         person.children.push(person2);
 
-        await nodenamo.update(person).from(Person).execute();
+        let result = await nodenamo.update(person).from(Person).execute();
+
+        assert.isUndefined(result);
 
         person = await nodenamo.get(0).from(Person).execute();
         assert.equal(person.children.length, 2);

--- a/spec/acceptance/multiValuesHashRangeTest.spec.ts
+++ b/spec/acceptance/multiValuesHashRangeTest.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 
 @DBTable({name:'nodenamo_acceptance_multiValuesHashRangeTest'})
 class User
@@ -270,7 +269,9 @@ describe('Multi-values Hash/Range tests', function ()
 
         user.name = 'This Three';
         user['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
 
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, new User({ id: 3, name: 'This Three', roles: ['user', 'admin'], departments: ['IT', 'HR'], createdTimestamp: 2014 }));

--- a/spec/acceptance/multiValuesHashTest.spec.ts
+++ b/spec/acceptance/multiValuesHashTest.spec.ts
@@ -2,7 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_multiValuesHashTest'})
 class User
@@ -315,7 +315,9 @@ describe('Multi-values Hash tests', function ()
 
         user.name = 'This Three';
         user['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
 
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, new User({ id: 3, name: 'This Three', roles: ['user', 'admin'] }));
@@ -367,6 +369,31 @@ describe('Multi-values Hash tests', function ()
         user = await nodenamo.get(6).from(User).execute();
         assert.deepEqual(user, new User({ id: 6, name: '', roles: ['user', 'admin'] }));
         assert.deepEqual((await nodenamo.list().from(User).execute()).items.length, 6);
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/multiValuesHashTest.spec.ts
+++ b/spec/acceptance/multiValuesHashTest.spec.ts
@@ -410,6 +410,43 @@ describe('Multi-values Hash tests', function ()
         assert.deepEqual(user, new User({id:6, name: 'Mr. Six', roles: ['user', 'admin']}));
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/multiValuesRangeTest.spec.ts
+++ b/spec/acceptance/multiValuesRangeTest.spec.ts
@@ -284,6 +284,43 @@ describe('Multi-values range tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, ranges: ['2020#6', 'true#6', 'Some Six#6'] });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/multiValuesRangeTest.spec.ts
+++ b/spec/acceptance/multiValuesRangeTest.spec.ts
@@ -2,7 +2,7 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable({name:'nodenamo_acceptance_multiValuesRangeTest'})
 class User
@@ -190,7 +190,9 @@ describe('Multi-values range tests', function ()
 
         user.name = 'This Three';
         user3['extra'] = 'invalid';
-        await nodenamo.update(user).from(User).execute();
+        let result = await nodenamo.update(user).from(User).execute();
+
+        assert.isUndefined(result);
         
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, { id: 3, name: 'This Three', account: 2000, ranges: ['2016#3', 'true#3', 'Some Three#3'] });
@@ -227,6 +229,45 @@ describe('Multi-values range tests', function ()
         
         user = await nodenamo.get(6).from(User).execute();
         assert.deepEqual(user, { id: 6, name: '', account: 3000, ranges: ['2020#6', 'true#6', 'Some Six#6'] });
+    });
+
+    it('Update an item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.AllOld).execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('Update an item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Newest Two'}).from(User).returning(ReturnValue.AllNew).execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'Newest Two'});
+    });
+
+    it('Update an item - return None', async () =>
+    {
+        let result = await nodenamo.update({id: 2, name: 'Newer Two'}).from(User).returning(ReturnValue.None).execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('Update an item - with all combinations', async () =>
+    {
+        let originalUser = await nodenamo.get(2).from(User).execute<User>();
+
+        let result = await nodenamo.update({id: 2, name: 'Another Two'})
+                                   .from(User)
+                                   .where('#account=:account', {'#account': 'account'}, {':account': originalUser.account})
+                                   .returning(ReturnValue.AllOld)
+                                   .withVersionCheck()
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
     });
 
     it('On item', async () =>

--- a/spec/acceptance/tableVersioningTest.spec.ts
+++ b/spec/acceptance/tableVersioningTest.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Reflector } from '../../src/reflector';
 import { VersionError } from '../../src/errors/versionError';
 
@@ -85,7 +84,9 @@ describe('Table versioning tests', function ()
         assert.deepEqual(user2, { id: 1, name: 'Some One', age: 16 });
         assert.equal(Reflector.getObjectVersion(user2), 1);
 
-        await nodenamo.update({id: 1, name: 'I am first'}).from(User).execute();
+        let result = await nodenamo.update({id: 1, name: 'I am first'}).from(User).execute();
+
+        assert.isUndefined(result);
         
         let user3 = await nodenamo.get(1).from(User).execute();
         assert.deepEqual(user3, { id: 1, name: 'I am first', age: 16 });

--- a/spec/acceptance/urlSafeFirstAndLastEvaluatedKeys.spec.ts
+++ b/spec/acceptance/urlSafeFirstAndLastEvaluatedKeys.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 
 @DBTable({name:'nodenamo_acceptance_hashRangeWithUnicodeTest'})
 class User

--- a/spec/acceptance/versionTest.spec.ts
+++ b/spec/acceptance/versionTest.spec.ts
@@ -2,7 +2,6 @@ import {assert as assert} from 'chai';
 import { DBTable, DBColumn } from '../../src';
 import { NodeNamo } from '../../src/nodeNamo';
 import Config from './config';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Reflector } from '../../src/reflector';
 import { VersionError } from '../../src/errors/versionError';
 
@@ -73,7 +72,9 @@ describe('Version tests', function ()
         assert.deepEqual(user2, { id: 1, name: 'Some One', age: 16 });
         assert.equal(Reflector.getObjectVersion(user2), 1);
 
-        await nodenamo.update({id: 1, name: 'I am first', age: undefined}).from(User).withVersionCheck().execute();
+        let result = await nodenamo.update({id: 1, name: 'I am first', age: undefined}).from(User).withVersionCheck().execute();
+
+        assert.isUndefined(result);
         
         let user3 = await nodenamo.get(1).from(User).execute();
         assert.deepEqual(user3, { id: 1, name: 'I am first', age: 16 });

--- a/spec/unit/dynamodbManagerApply.spec.ts
+++ b/spec/unit/dynamodbManagerApply.spec.ts
@@ -629,8 +629,8 @@ describe('DynamoDbManager.Apply()', function ()
             error = e;
         }
 
-        assert.notInstanceOf(error, VersionError);
         assert.equal(error?.message, 'Simulated error');
+        assert.notInstanceOf(error, VersionError);
         assert.isTrue(representationsToUpdateCreatedFromStronglyConsistentRead);
     });
 

--- a/spec/unit/dynamodbManagerUpdate.spec.ts
+++ b/spec/unit/dynamodbManagerUpdate.spec.ts
@@ -556,8 +556,8 @@ describe('DynamoDbManager.Update()', function ()
             error = e;
         }
 
-        assert.notInstanceOf(error, VersionError);
         assert.equal(error?.message, 'Simulated error');
+        assert.notInstanceOf(error, VersionError);
         assert.isTrue(desiredObjectCreatedFromStronglyConsistentRead);
     });
 

--- a/spec/unit/queryOn.spec.ts
+++ b/spec/unit/queryOn.spec.ts
@@ -4,6 +4,7 @@ import { IMock, Mock } from 'typemoq';
 import { DBTable } from '../../src/dbTable';
 import { DBColumn } from '../../src/dbColumn';
 import { On } from '../../src/queries/on/on';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable()
 class Entity {
@@ -108,6 +109,41 @@ describe('Query.On', function ()
         assert.isTrue(called);
     });
 
+    it('withVersionCheck() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .withVersionCheck()
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('returning()', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, returnValue: ReturnValue.AllNew}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .returning(ReturnValue.AllNew)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('returning() - with a version check', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, versionCheck: true, returnValue: ReturnValue.AllNew}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .returning(ReturnValue.AllNew)
+                                       .withVersionCheck()
+                                       .execute();
+        assert.isTrue(called);
+    });
+
     it('where()', async ()=>
     {
         mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}}, undefined, true)).callback(()=>called=true);
@@ -132,6 +168,45 @@ describe('Query.On', function ()
 
         new On(mockedManager.object, 1).from(Entity).add(['add1'], {n1:'n1'}, {v1:'v1'}).where('condition', {n2:'n2'}, {v2:'v2'}).withVersionCheck(false).execute();
 
+        assert.isTrue(called);
+    });
+
+    it('where() - with a version check and returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .withVersionCheck()
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('where() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+
+        assert.isTrue(called);
+    });
+
+    it('where() - with returning and versionCheck', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .returning(ReturnValue.AllOld)
+                                       .withVersionCheck()
+                                       .execute();
         assert.isTrue(called);
     });
 });

--- a/spec/unit/queryUpdate.spec.ts
+++ b/spec/unit/queryUpdate.spec.ts
@@ -4,6 +4,7 @@ import { IMock, Mock } from 'typemoq';
 import { DBTable } from '../../src/dbTable';
 import { DBColumn } from '../../src/dbColumn';
 import { Update } from '../../src/queries/update/update';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable()
 class Entity {
@@ -56,6 +57,80 @@ describe('Query.Update', function ()
         assert.isTrue(called);
     });
 
+    it('withVersionCheck() - with where', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            versionCheck: true
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .withVersionCheck(true)
+            .where('condition', {'name':'n'}, {'value':'v'});
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('withVersionCheck() - with where and returning', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            versionCheck: true,
+            returnValue: ReturnValue.None
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .withVersionCheck(true)
+            .where('condition', {'name':'n'}, {'value':'v'})
+            .returning(ReturnValue.None);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('withVersionCheck() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            versionCheck: true,
+            returnValue: ReturnValue.None
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .withVersionCheck(true)
+            .returning(ReturnValue.None);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('withVersionCheck() - with returning and where', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            versionCheck: true,
+            returnValue: ReturnValue.None
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .withVersionCheck(true)
+            .returning(ReturnValue.None)
+            .where('condition', {'name':'n'}, {'value':'v'});
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
     it('where()', async ()=>
     {
         mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
@@ -103,6 +178,146 @@ describe('Query.Update', function ()
             .from(Entity)
             .where('condition', {'name':'n'}, {'value':'v'})
             .withVersionCheck(false);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('where() - with a version check and returning', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            versionCheck: true,
+            returnValue: ReturnValue.AllNew
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .where('condition', {'name':'n'}, {'value':'v'})
+            .withVersionCheck(true)
+            .returning(ReturnValue.AllNew);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('where() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            returnValue: ReturnValue.AllNew
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .where('condition', {'name':'n'}, {'value':'v'})
+            .returning(ReturnValue.AllNew);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+    it('where() - with returning and a version check', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+            versionCheck: true,
+            returnValue: ReturnValue.AllNew
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .where('condition', {'name':'n'}, {'value':'v'})
+            .returning(ReturnValue.AllNew)
+            .withVersionCheck(true);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('returning()', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {returnValue:ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .returning(ReturnValue.AllOld);
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('returning() - with version check', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {returnValue:ReturnValue.AllOld, versionCheck: true}, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .returning(ReturnValue.AllOld)
+            .withVersionCheck();
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('returning() - with version check and where', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            returnValue:ReturnValue.AllOld, 
+            versionCheck: true, 
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .returning(ReturnValue.AllOld)
+            .withVersionCheck()
+            .where('condition', {'name':'n'}, {'value':'v'});
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('returning() - with where', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            returnValue:ReturnValue.AllOld, 
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .returning(ReturnValue.AllOld)
+            .where('condition', {'name':'n'}, {'value':'v'});
+        await update.execute();
+
+        assert.isTrue(called);
+    });
+
+    it('returning() - with where and version check', async ()=>
+    {
+        mockedManager.setup(m => m.update(Entity, 1, {id:1}, {
+            returnValue:ReturnValue.AllOld, 
+            versionCheck: true,
+            conditionExpression:'condition', 
+            expressionAttributeNames: {name: 'n'},
+            expressionAttributeValues: {value: 'v'},
+        }, undefined, true)).callback(()=>called=true);
+
+        let update = new Update(mockedManager.object, {id:1})
+            .from(Entity)
+            .returning(ReturnValue.AllOld)
+            .where('condition', {'name':'n'}, {'value':'v'})
+            .withVersionCheck();
         await update.execute();
 
         assert.isTrue(called);

--- a/src/dbColumn.ts
+++ b/src/dbColumn.ts
@@ -1,8 +1,8 @@
 import { Reflector } from "./reflector";
 
-export function DBColumn(params:{id?:boolean, name?:string, hash?:boolean|string, range?:boolean|string} = {}) 
+export function DBColumn(params:{id?:boolean, name?:string, hash?:boolean|string, range?:boolean|string} = {}): any
 {
-    return function(target: Object, propertyName: string): void
+    return function(target: Object, propertyName: string)
     {
         let value = params.name || propertyName;
         

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export * from './dbColumn';
 export * from './dbTable';
 export * from './nodeNamo';
 
+export * from './interfaces/returnValue';
+
 export * from './errors/nodenamoError';
 export * from './errors/validationError';
 export * from './errors/versionError';

--- a/src/interfaces/iDynamodbManager.ts
+++ b/src/interfaces/iDynamodbManager.ts
@@ -18,7 +18,7 @@ export interface IDynamoDbManager
 
     update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<T>;
 
-    apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
+    apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<T>;
 
     delete<T extends object>(type:{new(...args: any[]):T}, id:string|number,  params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
 

--- a/src/interfaces/iDynamodbManager.ts
+++ b/src/interfaces/iDynamodbManager.ts
@@ -1,5 +1,6 @@
 import { DynamoDbTransaction } from '../managers/dynamodbTransaction';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { ReturnValue } from './returnValue';
 
 export interface IDynamoDbManager
 {
@@ -15,7 +16,7 @@ export interface IDynamoDbManager
                                  params?:{limit?:number, fetchSize?:number, indexName?:string, order?:number, exclusiveStartKey?:string, projections?:string[], stronglyConsistent?:boolean})
                                  : Promise<{items:T[], lastEvaluatedKey: string, firstEvaluatedKey: string}>;
 
-    update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
+    update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<T>;
 
     apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
 

--- a/src/interfaces/returnValue.ts
+++ b/src/interfaces/returnValue.ts
@@ -1,0 +1,6 @@
+export enum ReturnValue
+{
+    None = "NONE",
+    AllOld = "ALL_OLD",
+    AllNew = "ALL_NEW",
+}

--- a/src/managers/dynamodbManager.ts
+++ b/src/managers/dynamodbManager.ts
@@ -11,6 +11,7 @@ import { Key } from '../Key';
 import AggregateError from 'aggregate-error';
 import base64url from "base64url";
 import { DynamoDBDocumentClient, QueryCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { ReturnValue } from '../interfaces/returnValue';
 
 export class DynamoDbManager implements IDynamoDbManager
 {
@@ -266,12 +267,13 @@ export class DynamoDbManager implements IDynamoDbManager
         }
     }    
 
-    async update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true)
+    async update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<T>
     {
         let instance = new type();
         let tableName = Reflector.getTableName(instance);
         let tableVersioning = Reflector.getTableVersioning(instance);
         let versioningRequired = tableVersioning || (params && params.versionCheck);
+        let returnValue:T = undefined;
 
         //Calculate new representations
         let [rows, stronglyConsistentRow ] = await Promise.all([this.getById(id, type), this.getOneRepresendationById(type,id,{ stronglyConsistent:true})]);
@@ -443,6 +445,17 @@ export class DynamoDbManager implements IDynamoDbManager
             }
 
             throw e;
+        }
+
+        //Return
+        switch(params?.returnValue)
+        {
+            case ReturnValue.AllOld:
+                return EntityFactory.create(type, stronglyConsistentRow);
+            case ReturnValue.AllNew:
+                return await this.getOne(type, id, {stronglyConsistent:true});
+            default:
+                return undefined;
         }
     }
 

--- a/src/managers/validatedDynamodbManager.ts
+++ b/src/managers/validatedDynamodbManager.ts
@@ -52,7 +52,7 @@ export class ValidatedDynamoDbManager implements IDynamoDbManager
         return await this.manager.find(type, keyParams, filterParams, params);
     }
 
-    async update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true)
+    async update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<T>
     {
         validateType(type);
         validateObject(type, obj);
@@ -60,7 +60,7 @@ export class ValidatedDynamoDbManager implements IDynamoDbManager
         validateKeyConditionExpression(type, params);
         validateVersioning(type, params);
 
-        await this.manager.update(type, id, obj, params, transaction, autoCommit);
+        return await this.manager.update(type, id, obj, params, transaction, autoCommit);
     }
 
     async apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true)

--- a/src/managers/validatedDynamodbManager.ts
+++ b/src/managers/validatedDynamodbManager.ts
@@ -63,13 +63,13 @@ export class ValidatedDynamoDbManager implements IDynamoDbManager
         return await this.manager.update(type, id, obj, params, transaction, autoCommit);
     }
 
-    async apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true)
+    async apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<T>
     {
         validateType(type);
         validateObjectId(id);
         validateUpdateExpression(type, params);
         validateVersioning(type, params);
-        await this.manager.apply(type, id, params, transaction, autoCommit)
+        return await this.manager.apply(type, id, params, transaction, autoCommit)
     }
 
     async delete<T extends object>(type:{new(...args: any[]):T}, id:string|number,  params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<void>

--- a/src/queries/on/add.ts
+++ b/src/queries/on/add.ts
@@ -7,10 +7,12 @@ import { Remove } from './remove';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Add implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, addExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, addExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Add implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/delete.ts
+++ b/src/queries/on/delete.ts
@@ -7,10 +7,12 @@ import { Add } from './add';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Delete implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, deleteExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, deleteExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Delete implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/execute.ts
+++ b/src/queries/on/execute.ts
@@ -1,15 +1,16 @@
 import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
+import { ReturnValue } from '../../interfaces/returnValue';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
 import { Reexecutable } from '../Reexecutable';
 
 export class Execute extends Reexecutable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params?:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, private transaction?:DynamoDbTransaction)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params?:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, private transaction?:DynamoDbTransaction)
     {
         super();
     }
 
-    async execute(): Promise<void>
+    async execute<T extends object>(): Promise<T>
     {
         return await super.execute(async ()=>
         {

--- a/src/queries/on/remove.ts
+++ b/src/queries/on/remove.ts
@@ -7,10 +7,12 @@ import { Add } from './add';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Remove implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, removeExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, removeExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Remove implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/returning.ts
+++ b/src/queries/on/returning.ts
@@ -1,0 +1,25 @@
+import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
+import { Execute } from "./execute";
+import { WithVersionCheck } from './withVersionCheck';
+import ITransactionable from '../../interfaces/iTransactionable';
+import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+
+export class Returning implements ITransactionable
+{
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, private returnValue:ReturnValue)
+    {
+        this.params = this.params || <any>{};
+        this.params['returnValue'] = returnValue;
+    }
+
+    withVersionCheck(versionCheck:boolean = true): WithVersionCheck
+    {
+        return new WithVersionCheck(this.manager, this.type, this.id, this.params, versionCheck);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
+    {
+        return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
+    }
+}

--- a/src/queries/on/set.ts
+++ b/src/queries/on/set.ts
@@ -7,10 +7,12 @@ import { Remove } from './remove';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { Returning } from './returning';
+import { ReturnValue } from '../../interfaces/returnValue';
 
 export class Set implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, setExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, setExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Set implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/where.ts
+++ b/src/queries/on/where.ts
@@ -3,6 +3,8 @@ import { Execute } from "./execute";
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Where implements ITransactionable
 {
@@ -13,12 +15,17 @@ export class Where implements ITransactionable
         this.params.expressionAttributeValues = Object.assign(Object.assign({}, this.params.expressionAttributeValues), condition?.expressionAttributeValues);
     }
 
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
     withVersionCheck(versionCheck:boolean = true): WithVersionCheck
     {
         return new WithVersionCheck(this.manager, this.type, this.id, this.params, versionCheck);
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/withVersionCheck.ts
+++ b/src/queries/on/withVersionCheck.ts
@@ -2,6 +2,8 @@ import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
 import { Execute } from "./execute";
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class WithVersionCheck implements ITransactionable
 {
@@ -11,7 +13,12 @@ export class WithVersionCheck implements ITransactionable
         this.params['versionCheck'] = versionCheck;
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/update/execute.ts
+++ b/src/queries/update/execute.ts
@@ -3,15 +3,16 @@ import { Reflector } from "../../reflector";
 import { Key } from '../../Key';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
 import { Reexecutable } from '../Reexecutable';
+import { ReturnValue } from '../../interfaces/returnValue';
 
 export class Execute extends Reexecutable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, private transaction?:DynamoDbTransaction)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, private transaction?:DynamoDbTransaction)
     {
         super()
     }
 
-    async execute(): Promise<void>
+    async execute<T extends object>(): Promise<T>
     {
         return await super.execute(async ()=>
         {

--- a/src/queries/update/from.ts
+++ b/src/queries/update/from.ts
@@ -4,6 +4,8 @@ import { Where } from "./where";
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class From implements ITransactionable
 {
@@ -22,7 +24,12 @@ export class From implements ITransactionable
         return new Where(this.manager, this.type, this.obj, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.obj, undefined, returnValue)
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.obj, undefined, transaction).execute();
     }

--- a/src/queries/update/returning.ts
+++ b/src/queries/update/returning.ts
@@ -4,18 +4,19 @@ import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
 import { ReturnValue } from '../../interfaces/returnValue';
-import { Returning } from './returning';
+import { Where } from './where';
 
-export class Where implements ITransactionable
+export class Returning implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object,  returnValue?:ReturnValue, versionCheck?:boolean})
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, returnValue?:ReturnValue, versionCheck?:boolean}, private returnValue?:ReturnValue)
     {
-
+        this.params = this.params || {};
+        this.params['returnValue'] = this.returnValue;
     }
 
-    returning(returnValue:ReturnValue): Returning
+    where(conditionExpression:string, expressionAttributeNames?:object, expressionAttributeValues?:object): Where
     {
-        return new Returning(this.manager, this.type, this.obj, this.params, returnValue);
+        return new Where(this.manager, this.type, this.obj, {...this.params, ...{conditionExpression, expressionAttributeNames, expressionAttributeValues}})
     }
 
     withVersionCheck(versionCheck:boolean = true): WithVersionCheck

--- a/src/queries/update/withVersionCheck.ts
+++ b/src/queries/update/withVersionCheck.ts
@@ -2,16 +2,29 @@ import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
 import { Execute } from "./execute";
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
+import { Where } from './where';
 
 export class WithVersionCheck implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object}, versionCheck?:boolean)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private obj:object, private params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, returnValue?:ReturnValue, versionCheck?:boolean}, versionCheck?:boolean)
     {
         this.params = this.params || {};
         this.params['versionCheck'] = versionCheck;
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.obj, this.params, returnValue);
+    }
+
+    where(conditionExpression:string, expressionAttributeNames?:object, expressionAttributeValues?:object): Where
+    {
+        return new Where(this.manager, this.type, this.obj, {...this.params, ...{conditionExpression, expressionAttributeNames, expressionAttributeValues}})
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.obj, this.params, transaction).execute();
     }


### PR DESCRIPTION
This MR allows callers to get the original object as it was before an update is made or the new object as it is after the update. Since TransactWriteItems does not support this feature, additional logic has been added to nodenamo to support this addition. Returning an old object does not incur additional cost. Returning a new object, however, involves an additional get query. The returned object, if any, is strongly consistent.