### PR TITLE
Added .returning() to apply()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ let user1 = await nodenamo.get(1).from(User).execute<User>();
 
 //Update the user
 user1.name = 'This One';
-await nodenamo.update(user1).from(User).execute(); 
-    /* Returns { items: [ User { id: 1, name: 'This One', email: 'some.one@example.com' } ],
-                 lastEvaluatedKey: undefined } */
+let originalUser = await nodenamo.update(user1).from(User).returning(ReturnValue.AllOld).execute(); 
+    /* Returns User { id: 1, name: 'Some One', email: 'some.one@example.com' } */
 
 //List all users
 let users = await nodenamo.list().from(User).execute<User>();
+    /* Returns { items: [ User { id: 1, name: 'This One', email: 'some.one@example.com' } ],
+                 lastEvaluatedKey: undefined } */
 
 //Delete the user by id
 await nodenamo.delete(1).from(User).execute();
@@ -192,6 +193,44 @@ where:
  * `hash` is the value of a hash key defined by `@DBColumn({hash:true})`
  * `range` is the prefix value of a range key defined by `@DBColumn({range:true})`
  * `indexName` is the name of an index to be used with the query.
+
+### <a name='Update'>Update an object</a>
+
+Get an object from DynamoDB by the object's ID
+
+```javascript
+// Update an object
+await nodenamo.update(object).from(T).execute<T>();
+
+// Update an object with a condition expression
+await nodenamo.update(object).from(T).where(conditionExpression, expressionAttributeNames, expressionAttributeValues).execute<T>();
+
+// Update an object and requesting for a return value.
+import { ReturnValue } from 'nodenamo';
+
+await nodenamo.update(object).from(T).returning(ReturnValue.AllOld).execute<T>();
+
+// Update an object with a version check
+await nodenamo.update(object).from(T).withVersionCheck().execute<T>();
+
+/***
+ * All operations above can be chained together.
+ ***/
+await nodenamo.update(obj)
+              .from(T)
+              .where(conditionExpression, expressionAttributeNames, expressionAttributeValues)
+              .withVersionCheck()
+              .returning(ReturnValue.AllNew)
+              .execute<T>();
+
+```
+
+where:
+ * `obj` is an object retrieved from the <a href='#Get'>Get</a> or <a href='#List'>List</a> operations or an object created from a class decorated with `@DBTable()`
+ * `T` is a class decorated with `@DBTable()`
+ * `conditionExpression` is a string representing a conditional expression for DynamoDB's PUT operation. For example, `"#name = :name"`
+ * `expressionAttributeNames` is an object representing attribute names for the conditionExpression. For example, `{ '#name': 'name' }`
+ * `expressionAttributeValues` is an object representing attribute values for the conditionExpression. For example, `{ ':name': 'Some One' }`
 
  ### Delete an object<a name='Delete'></a>
 

--- a/spec/acceptance/customNameTest.spec.ts
+++ b/spec/acceptance/customNameTest.spec.ts
@@ -341,6 +341,43 @@ describe('Custom-name tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020, department: 'hr', enabled: true });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/hashRangePairTest.spec.ts
+++ b/spec/acceptance/hashRangePairTest.spec.ts
@@ -416,6 +416,43 @@ describe('Hash-range pair tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020, parentId: 600 });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/hashRangeTest.spec.ts
+++ b/spec/acceptance/hashRangeTest.spec.ts
@@ -495,6 +495,43 @@ describe('Hash-range tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, created: 2020});
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/hashTest.spec.ts
+++ b/spec/acceptance/hashTest.spec.ts
@@ -422,6 +422,43 @@ describe('Hash tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 6000});
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/idTest.spec.ts
+++ b/spec/acceptance/idTest.spec.ts
@@ -236,7 +236,7 @@ describe('ID tests', function ()
         let result = await nodenamo.update(user3).from(User).execute();
 
         assert.isUndefined(result);
-        
+
         user = await nodenamo.get(3).from(User).execute();
         assert.deepEqual(user, {id:3, name: 'This Three', description: 'Description 3', secret: undefined, obj:{array:[], bool:true, empty:'', num:1, obj:{n:1,e:''}, str:'string'}});
     });
@@ -304,16 +304,55 @@ describe('ID tests', function ()
     {
         let user = await nodenamo.get(4).from(User).execute<User>();
 
-        await nodenamo.on(4)
-                      .from(User)
-                      .set(['#desc=:desc'], {'#desc': 'description'}, {':desc': 'That description'})
-                      .add(['#obj :obj'], {'#obj': 'obj'}, {':obj': 42})
-                      .remove(['#name'], {'#name': 'name'})
-                      .execute();
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#desc=:desc'], {'#desc': 'description'}, {':desc': 'That description'})
+                                   .add(['#obj :obj'], {'#obj': 'obj'}, {':obj': 42})
+                                   .remove(['#name'], {'#name': 'name'})
+                                   .execute();
 
         user = await nodenamo.get(4).from(User).execute();
 
+        assert.isUndefined(result);
+
         assert.deepEqual(user, {id:4, name: undefined, description: 'That description', secret: undefined, obj:<any>42});
+    });
+
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(4).from(User).execute<User>();
+
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(4).from(User).execute<User>();
+
+        let result = await nodenamo.on(4)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
     });
 
     it('Delete an item', async () =>

--- a/spec/acceptance/multiValuesHashTest.spec.ts
+++ b/spec/acceptance/multiValuesHashTest.spec.ts
@@ -410,6 +410,43 @@ describe('Multi-values Hash tests', function ()
         assert.deepEqual(user, new User({id:6, name: 'Mr. Six', roles: ['user', 'admin']}));
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/acceptance/multiValuesRangeTest.spec.ts
+++ b/spec/acceptance/multiValuesRangeTest.spec.ts
@@ -284,6 +284,43 @@ describe('Multi-values range tests', function ()
         assert.deepEqual(user, {id:6, name: 'Mr. Six', account: 3000, ranges: ['2020#6', 'true#6', 'Some Six#6'] });
     });
 
+    it('On item - return None', async () =>
+    {
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - None'})
+                                   .returning(ReturnValue.None)
+                                   .execute();
+
+        assert.isUndefined(result);
+    });
+
+    it('On item - return AllOld', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllOld'})
+                                   .returning(ReturnValue.AllOld)
+                                   .execute();
+
+        assert.deepEqual(result, originalUser);
+    });
+
+    it('On item - return AllNew', async () =>
+    {
+        let originalUser = await nodenamo.get(6).from(User).execute<User>();
+
+        let result = await nodenamo.on(6)
+                                   .from(User)
+                                   .set(['#name=:name'], {'#name': 'name'}, {':name': 'That name - AllNew'})
+                                   .returning(ReturnValue.AllNew)
+                                   .execute();
+
+        assert.deepEqual(result, {...originalUser, name: 'That name - AllNew'});
+    });
+
     it('Delete an item', async () =>
     {
         assert.isDefined(await nodenamo.get(1).from(User).execute());

--- a/spec/unit/queryOn.spec.ts
+++ b/spec/unit/queryOn.spec.ts
@@ -4,6 +4,7 @@ import { IMock, Mock } from 'typemoq';
 import { DBTable } from '../../src/dbTable';
 import { DBColumn } from '../../src/dbColumn';
 import { On } from '../../src/queries/on/on';
+import { ReturnValue } from '../../src/interfaces/returnValue';
 
 @DBTable()
 class Entity {
@@ -108,6 +109,41 @@ describe('Query.On', function ()
         assert.isTrue(called);
     });
 
+    it('withVersionCheck() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .withVersionCheck()
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('returning()', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, returnValue: ReturnValue.AllNew}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .returning(ReturnValue.AllNew)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('returning() - with a version check', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, expressionAttributeNames: {n1:'n1'}, expressionAttributeValues: {v1:'v1'}, versionCheck: true, returnValue: ReturnValue.AllNew}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .returning(ReturnValue.AllNew)
+                                       .withVersionCheck()
+                                       .execute();
+        assert.isTrue(called);
+    });
+
     it('where()', async ()=>
     {
         mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}}, undefined, true)).callback(()=>called=true);
@@ -132,6 +168,45 @@ describe('Query.On', function ()
 
         new On(mockedManager.object, 1).from(Entity).add(['add1'], {n1:'n1'}, {v1:'v1'}).where('condition', {n2:'n2'}, {v2:'v2'}).withVersionCheck(false).execute();
 
+        assert.isTrue(called);
+    });
+
+    it('where() - with a version check and returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .withVersionCheck()
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+        assert.isTrue(called);
+    });
+
+    it('where() - with returning', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .returning(ReturnValue.AllOld)
+                                       .execute();
+
+        assert.isTrue(called);
+    });
+
+    it('where() - with returning and versionCheck', async ()=>
+    {
+        mockedManager.setup(m => m.apply(Entity, 1, {updateExpression: {add: ['add1']}, conditionExpression: 'condition', expressionAttributeNames: {n1:'n1', n2:'n2'}, expressionAttributeValues: {v1:'v1', v2:'v2'}, versionCheck: true, returnValue: ReturnValue.AllOld}, undefined, true)).callback(()=>called=true);
+
+        new On(mockedManager.object, 1).from(Entity)
+                                       .add(['add1'], {n1:'n1'}, {v1:'v1'})
+                                       .where('condition', {n2:'n2'}, {v2:'v2'})
+                                       .returning(ReturnValue.AllOld)
+                                       .withVersionCheck()
+                                       .execute();
         assert.isTrue(called);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export * from './dbColumn';
 export * from './dbTable';
 export * from './nodeNamo';
 
+export * from './interfaces/returnValue';
+
 export * from './errors/nodenamoError';
 export * from './errors/validationError';
 export * from './errors/versionError';

--- a/src/interfaces/iDynamodbManager.ts
+++ b/src/interfaces/iDynamodbManager.ts
@@ -18,7 +18,7 @@ export interface IDynamoDbManager
 
     update<T extends object>(type:{new(...args: any[]):T}, id:string|number, obj:object, params?:{conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<T>;
 
-    apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
+    apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<T>;
 
     delete<T extends object>(type:{new(...args: any[]):T}, id:string|number,  params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object}, transaction?:DynamoDbTransaction, autoCommit?:boolean): Promise<void>;
 

--- a/src/managers/validatedDynamodbManager.ts
+++ b/src/managers/validatedDynamodbManager.ts
@@ -63,13 +63,13 @@ export class ValidatedDynamoDbManager implements IDynamoDbManager
         return await this.manager.update(type, id, obj, params, transaction, autoCommit);
     }
 
-    async apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true)
+    async apply<T extends object>(type:{new(...args: any[]):T}, id:string|number, params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<T>
     {
         validateType(type);
         validateObjectId(id);
         validateUpdateExpression(type, params);
         validateVersioning(type, params);
-        await this.manager.apply(type, id, params, transaction, autoCommit)
+        return await this.manager.apply(type, id, params, transaction, autoCommit)
     }
 
     async delete<T extends object>(type:{new(...args: any[]):T}, id:string|number,  params?:{conditionExpression:string, expressionAttributeValues?:object, expressionAttributeNames?:object}, transaction?:DynamoDbTransaction, autoCommit:boolean = true): Promise<void>

--- a/src/queries/on/add.ts
+++ b/src/queries/on/add.ts
@@ -7,10 +7,12 @@ import { Remove } from './remove';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Add implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, addExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, addExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Add implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/delete.ts
+++ b/src/queries/on/delete.ts
@@ -7,10 +7,12 @@ import { Add } from './add';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Delete implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, deleteExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, deleteExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Delete implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/execute.ts
+++ b/src/queries/on/execute.ts
@@ -1,15 +1,16 @@
 import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
+import { ReturnValue } from '../../interfaces/returnValue';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
 import { Reexecutable } from '../Reexecutable';
 
 export class Execute extends Reexecutable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params?:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, private transaction?:DynamoDbTransaction)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params?:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, private transaction?:DynamoDbTransaction)
     {
         super();
     }
 
-    async execute(): Promise<void>
+    async execute<T extends object>(): Promise<T>
     {
         return await super.execute(async ()=>
         {

--- a/src/queries/on/remove.ts
+++ b/src/queries/on/remove.ts
@@ -7,10 +7,12 @@ import { Add } from './add';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Remove implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, removeExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, removeExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Remove implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/returning.ts
+++ b/src/queries/on/returning.ts
@@ -1,0 +1,25 @@
+import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
+import { Execute } from "./execute";
+import { WithVersionCheck } from './withVersionCheck';
+import ITransactionable from '../../interfaces/iTransactionable';
+import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+
+export class Returning implements ITransactionable
+{
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, private returnValue:ReturnValue)
+    {
+        this.params = this.params || <any>{};
+        this.params['returnValue'] = returnValue;
+    }
+
+    withVersionCheck(versionCheck:boolean = true): WithVersionCheck
+    {
+        return new WithVersionCheck(this.manager, this.type, this.id, this.params, versionCheck);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
+    {
+        return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
+    }
+}

--- a/src/queries/on/set.ts
+++ b/src/queries/on/set.ts
@@ -7,10 +7,12 @@ import { Remove } from './remove';
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { Returning } from './returning';
+import { ReturnValue } from '../../interfaces/returnValue';
 
 export class Set implements ITransactionable
 {
-    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean}, setExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
+    constructor(private manager:IDynamoDbManager, private type:{new(...args: any[])}, private id:string|number, private params:{updateExpression:{set?:string[], remove?:string[], add?:string[], delete?:string[]}, conditionExpression?:string, expressionAttributeValues?:object, expressionAttributeNames?:object, versionCheck?:boolean, returnValue?:ReturnValue}, setExpressions:string[], expressionAttributeNames?:object, expressionAttributeValues?:object)
     {
 
         if(this.params === undefined) this.params = <any>{};
@@ -52,7 +54,12 @@ export class Set implements ITransactionable
         return new Where(this.manager, this.type, this.id, this.params, {conditionExpression, expressionAttributeNames, expressionAttributeValues})
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/where.ts
+++ b/src/queries/on/where.ts
@@ -3,6 +3,8 @@ import { Execute } from "./execute";
 import { WithVersionCheck } from './withVersionCheck';
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class Where implements ITransactionable
 {
@@ -13,12 +15,17 @@ export class Where implements ITransactionable
         this.params.expressionAttributeValues = Object.assign(Object.assign({}, this.params.expressionAttributeValues), condition?.expressionAttributeValues);
     }
 
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
     withVersionCheck(versionCheck:boolean = true): WithVersionCheck
     {
         return new WithVersionCheck(this.manager, this.type, this.id, this.params, versionCheck);
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }

--- a/src/queries/on/withVersionCheck.ts
+++ b/src/queries/on/withVersionCheck.ts
@@ -2,6 +2,8 @@ import { IDynamoDbManager } from '../../interfaces/iDynamodbManager';
 import { Execute } from "./execute";
 import ITransactionable from '../../interfaces/iTransactionable';
 import { DynamoDbTransaction } from '../../managers/dynamodbTransaction';
+import { ReturnValue } from '../../interfaces/returnValue';
+import { Returning } from './returning';
 
 export class WithVersionCheck implements ITransactionable
 {
@@ -11,7 +13,12 @@ export class WithVersionCheck implements ITransactionable
         this.params['versionCheck'] = versionCheck;
     }
 
-    async execute(transaction?:DynamoDbTransaction): Promise<void>
+    returning(returnValue:ReturnValue): Returning
+    {
+        return new Returning(this.manager, this.type, this.id, this.params, returnValue);
+    }
+
+    async execute<T extends object>(transaction?:DynamoDbTransaction): Promise<T>
     {
         return await new Execute(this.manager, this.type, this.id, this.params, transaction).execute();
     }


### PR DESCRIPTION
This is the second MR to add support for returning().  

This MR allows callers to get the original object as it was before an update is made or the new object as it is after the update. Since TransactWriteItems does not support this feature, additional logic has been added to nodenamo to support this addition. Returning an old object does not incur additional cost. Returning a new object, however, involves an additional get query. The returned object, if any, is strongly consistent.